### PR TITLE
Emergency style fix 1 [QC-125]

### DIFF
--- a/pages/chain/[chainId]/[address]/index.tsx
+++ b/pages/chain/[chainId]/[address]/index.tsx
@@ -502,7 +502,7 @@ const QuestChainPage: React.FC<Props> = ({
 
           {/* quest chain */}
           <Flex
-            gap={10}
+            gap={20}
             justifyContent="space-between"
             direction={{ base: 'column', lg: 'row' }}
           >
@@ -511,7 +511,7 @@ const QuestChainPage: React.FC<Props> = ({
               {/* quest chain Title */}
               <Flex justifyContent="space-between" w="full">
                 {!isEditingQuestChain && (
-                  <Flex flexDirection="column" mb={8}>
+                  <Flex flexDirection="column" mb={8} w="full">
                     <Text
                       fontSize="5xl"
                       fontWeight="bold"
@@ -909,6 +909,7 @@ const QuestChainPage: React.FC<Props> = ({
                 flexDirection="column"
                 w="100%"
                 display={{ base: 'none', lg: 'flex' }}
+                mb={16}
               >
                 <ActionsAndImage
                   mode={mode}


### PR DESCRIPTION
- now the quest chain page has increased padding between the left and right column & the NFT and members
- the share buttons are aligned to the right of the left column
<img width="1452" alt="Screenshot 2022-11-27 at 15 11 25" src="https://user-images.githubusercontent.com/35112939/204139718-50267f79-1d59-4172-ad9a-0ca89ec50912.png">
