### PR TITLE
Add `react-medium-image-zoom` to zoom submission images [QC-174]

### DIFF
--- a/assets/styles/react-medium-image-zoom.css
+++ b/assets/styles/react-medium-image-zoom.css
@@ -1,0 +1,97 @@
+[data-rmiz] {
+  position: relative;
+}
+[data-rmiz-ghost] {
+  position: absolute;
+  pointer-events: none;
+}
+[data-rmiz-btn-zoom],
+[data-rmiz-btn-unzoom] {
+  background-color: rgba(0, 0, 0, 0.7);
+  border-radius: 50%;
+  border: none;
+  box-shadow: 0 0 1px rgba(255, 255, 255, 0.5);
+  color: #fff;
+  height: 40px;
+  margin: 0;
+  outline-offset: 2px;
+  padding: 9px;
+  touch-action: manipulation;
+  width: 40px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+[data-rmiz-btn-zoom]:not(:focus):not(:active) {
+  position: absolute;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  pointer-events: none;
+  white-space: nowrap;
+  width: 1px;
+}
+[data-rmiz-btn-zoom] {
+  position: absolute;
+  inset: 10px 10px auto auto;
+  cursor: zoom-in;
+}
+[data-rmiz-btn-unzoom] {
+  position: absolute;
+  inset: 20px 20px auto auto;
+  cursor: zoom-out;
+  z-index: 1;
+}
+[data-rmiz-content='found'] img,
+[data-rmiz-content='found'] svg,
+[data-rmiz-content='found'] [role='img'],
+[data-rmiz-content='found'] [data-zoom] {
+  cursor: zoom-in;
+}
+[data-rmiz-modal]::backdrop {
+  display: none;
+}
+[data-rmiz-modal][open] {
+  position: fixed;
+  width: 100vw;
+  width: 100svw;
+  height: 100vh;
+  height: 100svh;
+  max-width: none;
+  max-height: none;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  overflow: hidden;
+}
+[data-rmiz-modal-overlay] {
+  position: absolute;
+  inset: 0;
+  transition: background-color 0.3s;
+}
+[data-rmiz-modal-overlay='hidden'] {
+  background-color: rgba(255, 255, 255, 0);
+}
+[data-rmiz-modal-overlay='visible'] {
+  background-color: rgba(255, 255, 255, 1);
+}
+[data-rmiz-modal-content] {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+[data-rmiz-modal-img] {
+  position: absolute;
+  cursor: zoom-out;
+  image-rendering: high-quality;
+  transform-origin: top left;
+  transition: transform 0.3s;
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-rmiz-modal-overlay],
+  [data-rmiz-modal-img] {
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/assets/styles/react-medium-image-zoom.css
+++ b/assets/styles/react-medium-image-zoom.css
@@ -75,7 +75,7 @@
   background-color: rgba(255, 255, 255, 0);
 }
 [data-rmiz-modal-overlay='visible'] {
-  background-color: rgba(255, 255, 255, 1);
+  background-color: rgba(255, 255, 255, 0);
 }
 [data-rmiz-modal-content] {
   position: relative;

--- a/components/Review/SubmissionTile.tsx
+++ b/components/Review/SubmissionTile.tsx
@@ -1,5 +1,3 @@
-import 'react-medium-image-zoom/dist/styles.css';
-
 import { AttachmentIcon, CheckIcon, CloseIcon } from '@chakra-ui/icons';
 import {
   AccordionButton,

--- a/components/Review/SubmissionTile.tsx
+++ b/components/Review/SubmissionTile.tsx
@@ -1,3 +1,5 @@
+import 'react-medium-image-zoom/dist/styles.css';
+
 import { AttachmentIcon, CheckIcon, CloseIcon } from '@chakra-ui/icons';
 import {
   AccordionButton,
@@ -16,6 +18,7 @@ import {
 } from '@chakra-ui/react';
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'react-hot-toast';
+import Zoom from 'react-medium-image-zoom';
 import removeMd from 'remove-markdown';
 
 import { CommentIcon } from '@/components/icons/CommentIcon';
@@ -107,23 +110,16 @@ export const SubmissionTile: React.FC<{
                 </AccordionButton>
               </Flex>
             </Flex>
-            <Flex w="full" h="full" gap={2} pr={8} position="relative">
+            <Flex w="full" h="full" gap={4} pr={8} position="relative">
               {imageUrl && (
-                <Link
-                  isExternal
-                  href={imageUrl}
-                  _hover={{}}
-                  minW="fit-content"
-                  minH="fit-content"
-                >
+                <Zoom>
                   <Image
                     src={imageUrl}
                     alt="submission pic"
                     w={isExpanded ? '18rem' : '6rem'}
                     minH="fit-content"
-                    pr={4}
                   />
-                </Link>
+                </Zoom>
               )}
 
               <Box flexGrow={1}>

--- a/components/UploadImageForm.tsx
+++ b/components/UploadImageForm.tsx
@@ -10,6 +10,7 @@ import {
 } from '@chakra-ui/react';
 import { ImageProps } from 'next/image';
 import { useEffect, useState } from 'react';
+import Zoom from 'react-medium-image-zoom';
 
 import { DropImageType } from '@/hooks/useDropFiles';
 
@@ -54,11 +55,13 @@ export const UploadImageForm = ({
       {imageFile && (
         <Flex pos="relative" {...(isDisabled ? { pointerEvents: 'none' } : {})}>
           {ready && (
-            <Image
-              {...imageProps}
-              alt={`${label} imageFile`}
-              src={window.URL.createObjectURL(imageFile)}
-            />
+            <Zoom>
+              <Image
+                {...imageProps}
+                alt={`${label} imageFile`}
+                src={window.URL.createObjectURL(imageFile)}
+              />
+            </Zoom>
           )}
           <IconButton
             pos="absolute"
@@ -77,11 +80,14 @@ export const UploadImageForm = ({
       )}
       {!imageFile && defaultImageUri && onResetDefaultImage && (
         <Flex pos="relative" {...(isDisabled ? { pointerEvents: 'none' } : {})}>
-          <Image
-            {...imageProps}
-            alt={`${label} imageFile`}
-            src={defaultImageUri}
-          />
+          <Zoom>
+            <Image
+              {...imageProps}
+              alt={`${label} imageFile`}
+              src={defaultImageUri}
+            />
+          </Zoom>
+
           <IconButton
             pos="absolute"
             size="sm"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-hotjar": "^5.4.1",
     "react-markdown": "^8.0.3",
     "react-markdown-editor-lite": "^1.3.3",
+    "react-medium-image-zoom": "^5.1.2",
     "react-scroll": "^1.8.7",
     "react-select": "^5.7.0",
     "react-share": "^4.4.1",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,6 +2,7 @@ import '@/assets/styles/bg.scss';
 import '@/assets/styles/fonts.css';
 import 'react-markdown-editor-lite/lib/index.css';
 import '@/assets/styles/custom-markdown-editor.scss';
+import '@/assets/styles/react-medium-image-zoom.css';
 
 // Do NOT change order of CSS files
 import { ChakraProvider, useColorMode } from '@chakra-ui/react';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6923,6 +6923,11 @@ react-markdown@^8.0.3:
     unist-util-visit "^4.0.0"
     vfile "^5.0.0"
 
+react-medium-image-zoom@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/react-medium-image-zoom/-/react-medium-image-zoom-5.1.2.tgz#ff13b8cf37e3348c36a2fc6deade84912fdad8ce"
+  integrity sha512-Lk9TDqd+vUpQVP77p45jXgh1LGjClLfyLJnTemCfpI+5Zp3X7MX7iGP5VmSdLGXy9mhdlZiByHOyp4Irf4N8vg==
+
 react-merge-refs@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"


### PR DESCRIPTION
Prototype to fix https://github.com/quest-chains/dapp/issues/141.

Before clicking on the image: 
<img width="1800" alt="Screenshot 2023-02-10 at 3 04 56 PM" src="https://user-images.githubusercontent.com/45873074/218056829-a32fdfee-1100-4a47-95d3-360e68a8d84e.png">

After clicking on the image: 
<img width="1800" alt="Screenshot 2023-02-10 at 3 09 25 PM" src="https://user-images.githubusercontent.com/45873074/218057725-a69566b9-3c76-4dda-9ab1-d51ac0af228e.png">

If everyone is okay with this approach, then we can replicate this at other places. The minified (gzipped) import cost is 4.4k.