### PR TITLE
Ensure wallet is connected before Quest Creation (Get Started) [QC-175]

### DIFF
--- a/pages/create.tsx
+++ b/pages/create.tsx
@@ -280,7 +280,13 @@ const Create: React.FC = () => {
                 GET STARTED
               </SubmitButton>
             ) : (
-              <SubmitButton onClick={connectWallet} px={32}>
+              <SubmitButton
+                onClick={async () => {
+                  await connectWallet();
+                  setStep(1);
+                }}
+                px={32}
+              >
                 Connect wallet to Get Started
               </SubmitButton>
             )}

--- a/pages/create.tsx
+++ b/pages/create.tsx
@@ -46,7 +46,7 @@ import { AVAILABLE_NETWORK_INFO, isSupportedNetwork, useWallet } from '@/web3';
 const Create: React.FC = () => {
   const router = useRouter();
 
-  const { address, provider, chainId, globalInfo } = useWallet();
+  const { address, provider, chainId, globalInfo, connectWallet } = useWallet();
 
   const [chainName, setChainName] = useState('');
   const [chainDescription, setChainDescription] = useState('');
@@ -275,9 +275,15 @@ const Create: React.FC = () => {
         <Flex w="full" flexDir="column" gap={8}>
           <Step0 />
           <Flex w="full" justifyContent="center">
-            <SubmitButton onClick={() => setStep(1)} px={32}>
-              GET STARTED
-            </SubmitButton>
+            {address ? (
+              <SubmitButton onClick={() => setStep(1)} px={32}>
+                GET STARTED
+              </SubmitButton>
+            ) : (
+              <SubmitButton onClick={connectWallet} px={32}>
+                Connect wallet to Get Started
+              </SubmitButton>
+            )}
           </Flex>
         </Flex>
       )}


### PR DESCRIPTION
This PR would fix https://github.com/quest-chains/dapp/issues/128. By checking if a user wallet is connected before "Get Started" 

Note: If someone disconnects the wallet after "Get Started" then again "Step 2" will be disabled without feedback. 
